### PR TITLE
Use mopidy v1.0 uris param when adding to tracklist.

### DIFF
--- a/mopidy_musicbox_webclient/static/js/functionsvars.js
+++ b/mopidy_musicbox_webclient/static/js/functionsvars.js
@@ -65,6 +65,7 @@ PLAY_NEXT = 1;
 ADD_THIS_BOTTOM = 2;
 ADD_ALL_BOTTOM = 3;
 PLAY_ALL = 4;
+PLAY_NOW_SEARCH = 5;
 
 MAX_TABLEROWS = 50;
 
@@ -409,14 +410,28 @@ function getPlaylistFromUri(uri) {
     }
 }
 
-function getTracksFromUri(uri) {
-    var pl = getPlaylistFromUri(uri);
-    if (pl) {
-        return pl.tracks;
-    } else if (customTracklists[uri]) {
-        return customTracklists[uri];
+function getUris(tracks) {
+    var results = [];
+    for (var i = 0; i < tracks.length; i++) {
+        results.push(tracks[i].uri);
     }
-    return [];
+    return results;
+}
+
+function getTracksFromUri(uri, full_track_data) {
+    full_track_data = full_track_data || false;
+    var pl = getPlaylistFromUri(uri);
+    var tracks = [];
+    if (pl) {
+        tracks = pl.tracks;
+    } else if (customTracklists[uri]) {
+        tracks = customTracklists[uri];
+    }
+    if (full_track_data) {
+        return tracks;
+    } else {
+        return getUris(tracks);
+    }
 }
 
 //convert time to human readable format

--- a/mopidy_musicbox_webclient/static/js/library.js
+++ b/mopidy_musicbox_webclient/static/js/library.js
@@ -220,10 +220,10 @@ function getBrowseDir(rootdir) {
     //  get directory to browse
     showLoading(true);
     if (!rootdir) {
-	browseStack.pop();
-	rootdir = browseStack[browseStack.length - 1];
+        browseStack.pop();
+        rootdir = browseStack[browseStack.length - 1];
     } else {
-	browseStack.push(rootdir);
+        browseStack.push(rootdir);
     }
     mopidy.library.browse(rootdir).then(processBrowseDir, console.error);
 }
@@ -300,7 +300,7 @@ function showAlbum(uri) {
     $('#controlsmodal').popup('close');
     $(ALBUM_TABLE).empty();
     //fill from cache
-    var pl = getTracksFromUri(uri);
+    var pl = getTracksFromUri(uri, true);
     if (pl.length>0) {
         albumTracksToTable(pl, ALBUM_TABLE, uri);
         var albumname = getAlbum(pl);


### PR DESCRIPTION
Stop using deprecated tracks parameter when manipulating the tracklist and use lightweight uris instead. This is a better fix for #111.