### PR TITLE
Refactor cover art retrieval

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,7 @@ v2.2.0 (UNRELEASED)
 - Scrolling now works in full screen mode for Chrome and Safari as well. (Fixes: `#53 <https://github.com/pimusicbox/mopidy-musicbox-webclient/issues/53>`_).
 - No longer interferes with changes to Mopidy's volume levels that are triggered externally. (Fixes: `#162 <https://github.com/pimusicbox/mopidy-musicbox-webclient/issues/162>`_).
 - Volume slider now works with Mopidy-ALSAMixer again. (Fixes: `#168 <https://github.com/pimusicbox/mopidy-musicbox-webclient/issues/168>`_).
+- Now falls back to track artist if album artist is not available for rendering cover art. (Fixes: `#128 <https://github.com/pimusicbox/mopidy-musicbox-webclient/issues/128>`_).
 
 v2.1.1 (2016-02-04)
 -------------------

--- a/mopidy_musicbox_webclient/static/js/functionsvars.js
+++ b/mopidy_musicbox_webclient/static/js/functionsvars.js
@@ -343,10 +343,10 @@ function resultsToTables(results, target, uri) {
                     }
                     newalbum = [];
                     newtlids = [];
+                    if (results[i].album) {
+                        coversList.push([results[i].uri, i]);
+                    }
                 } //newalbum length
-                if (results[i].album) {
-                    coversList.push([results[i].uri, i]);
-                }
             } //albums name
         }
     }

--- a/mopidy_musicbox_webclient/static/js/functionsvars.js
+++ b/mopidy_musicbox_webclient/static/js/functionsvars.js
@@ -224,7 +224,7 @@ function resultsToTables(results, target, uri) {
 
     var newalbum = [];
     var newtlids = [];
-    //keep a list of albums for retreiving of covers
+    //keep a list of track URIs for retrieving of covers
     var coversList = [];
     var nextname = '';
     var count = 0;
@@ -343,12 +343,9 @@ function resultsToTables(results, target, uri) {
                     }
                     newalbum = [];
                     newtlids = [];
-                    if (results[i].album) {
-                        coversList.push([results[i].album, i]);
-                    }
                 } //newalbum length
                 if (results[i].album) {
-                    coversList.push([results[i].album, i]);
+                    coversList.push([results[i].uri, i]);
                 }
             } //albums name
         }
@@ -356,7 +353,7 @@ function resultsToTables(results, target, uri) {
     tableid = "#" + tableid;
     $(target).html(html);
     $(target).attr('data', uri);
-    //retreive albumcovers
+    //retrieve albumcovers
     for (i = 0; i < coversList.length; i++) {
         getCover(coversList[i][0], target + '-cover-' + coversList[i][1], 'small');
     }

--- a/mopidy_musicbox_webclient/static/js/gui.js
+++ b/mopidy_musicbox_webclient/static/js/gui.js
@@ -129,7 +129,7 @@ function setSongInfo(data) {
     }
     if (data.track.album && data.track.album.name) {
         $("#modalalbum").html('<a href="#" onclick="return showAlbum(\'' + data.track.album.uri + '\');">' + data.track.album.name + '</a>');
-        getCover(data.track.album, '#infocover, #controlspopupimage', 'extralarge');
+        getCover(data.track.uri, '#infocover, #controlspopupimage', 'extralarge');
     } else {
         $("#modalalbum").html('');
         $("#infocover").attr('src', 'images/default_cover.png');

--- a/mopidy_musicbox_webclient/static/js/process_ws.js
+++ b/mopidy_musicbox_webclient/static/js/process_ws.js
@@ -115,9 +115,9 @@ function processBrowseDir(resultArr) {
         if (resultArr[i].type == 'track') {
             //console.log(resultArr[i]);
             mopidy.library.lookup({'uris': [resultArr[i].uri]}).then(function (resultDict) {
-                var lookup_uri = Object.keys(resultDict)[0];
-                popupData[lookup_uri] = resultDict[lookup_uri][0];
-                browseTracks.push(resultDict[lookup_uri][0]);
+                var lookupUri = Object.keys(resultDict)[0];
+                popupData[lookupUri] = resultDict[lookupUri][0];
+                browseTracks.push(resultDict[lookupUri][0]);
             }, console.error);
             child += '<li class="song albumli" id="browselisttracks-' + resultArr[i].uri + '">' +
                      '<a href="#" class="moreBtn" onclick="return popupTracks(event, \'' + uri + '\', \'' + resultArr[i].uri + '\', \'' + index + '\');">' +
@@ -249,6 +249,6 @@ function processAlbumResults(resultArr) {
     $('#h_albumartist').html(artistname);
     $('#coverpopupalbumname').html(albumname);
     $('#coverpopupartist').html(artistname);
-    getCover(resultArr[0].album, '#albumviewcover, #coverpopupimage', 'extralarge');
+    getCover(resultArr[0].uri, '#albumviewcover, #coverpopupimage', 'extralarge');
     showLoading(false);
 }


### PR DESCRIPTION
I've refactored the Javascript routines for retrieving album covers:

- Optimised to pass track URI's instead of full album models.
- Now uses the new ``mopidy.library.getImages`` convention before falling back to the deprecated ``album.images`` approach.
- Now also falls back to using track artist when doing lookups on last.fm if album artist is not available (fixes #128).

Just for the avoidance of doubt, the order of precedence is: ``mopidy.library.getImages`` -> ``album.images`` -> last.fm