### PR TITLE
Convert to MVC-based architecture (Tornado template alternative)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 MANIFEST
 build/
 cover/
-coverage/
+.karma_coverage/
 coverage.xml
 dist/
 docs/_build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
-sudo: false
+sudo: required
+dist: trusty
 
 language: python
 
 python:
   - "2.7_with_system_site_packages"
+
+addons:
+  apt:
+    sources:
+      - mopidy-stable
+    packages:
+      - mopidy
 
 env:
   - TOX_ENV=py27
@@ -13,6 +21,10 @@ env:
   - TOX_ENV=csslint
   - TOX_ENV=tidy
 
+before_install:
+  - "sudo apt-get update -qq"
+  - "sudo apt-get install -y gstreamer0.10-plugins-good python-gst0.10"
+
 install:
   - "pip install tox"
 
@@ -20,6 +32,4 @@ script:
   - "tox -e $TOX_ENV"
 
 after_success:
-  # TODO: find a way to combine .py and .js coverage reports.
-  # - "if [ $TOX_ENV == 'py27' ]; then pip install coveralls; coveralls; fi"
-  - "if [ $TOX_ENV == 'test' ]; then cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js; fi"
+  - "if [ $TOX_ENV == 'test' ]; then pip install coveralls; coveralls --merge=./karma_coverage/coverage-final.json; fi"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -71,9 +71,10 @@ module.exports = function (config) {
 
         coverageReporter: {
             // specify a common output directory
-            dir: 'coverage/',
+            dir: '.karma_coverage/',
             reporters: [
                 { type: 'lcov', subdir: '.' },
+                { type: 'json', subdir: '.' },
                 { type: 'text' }
             ]
         }

--- a/mopidy_musicbox_webclient/__init__.py
+++ b/mopidy_musicbox_webclient/__init__.py
@@ -7,7 +7,7 @@ from mopidy import config, ext
 __version__ = '2.2.0'
 
 
-class MusicBoxExtension(ext.Extension):
+class Extension(ext.Extension):
 
     dist_name = 'Mopidy-MusicBox-Webclient'
     ext_name = 'musicbox_webclient'
@@ -18,10 +18,11 @@ class MusicBoxExtension(ext.Extension):
         return config.read(conf_file)
 
     def get_config_schema(self):
-        schema = super(MusicBoxExtension, self).get_config_schema()
+        schema = super(Extension, self).get_config_schema()
         schema['musicbox'] = config.Boolean(optional=True)
         schema['websocket_host'] = config.Hostname(optional=True)
         schema['websocket_port'] = config.Port(optional=True)
+        schema['search_blacklist'] = config.List(optional=True)
         return schema
 
     def setup(self, registry):
@@ -30,10 +31,11 @@ class MusicBoxExtension(ext.Extension):
 
     def factory(self, config, core):
         from tornado.web import RedirectHandler
-        from .web import IndexHandler, StaticHandler
+        from .web import IndexHandler, ScriptHandler, StaticHandler
         path = os.path.join(os.path.dirname(__file__), 'static')
         return [
             (r'/', RedirectHandler, {'url': 'index.html'}),
-            (r'/(index.html)', IndexHandler, {'config': config, 'path': path}),
+            (r'/(.*\.html)', IndexHandler, {'config': config, 'core': core, 'path': path}),
+            (r'/(.*\library.js)', ScriptHandler, {'config': config, 'core': core, 'path': path}),
             (r'/(.*)', StaticHandler, {'path': path})
         ]

--- a/mopidy_musicbox_webclient/ext.conf
+++ b/mopidy_musicbox_webclient/ext.conf
@@ -3,3 +3,15 @@ enabled = true
 musicbox = false
 websocket_host =
 websocket_port =
+
+# List of Mopidy URI schemes that should not be searched directly.
+# Also blacklists 'yt' in favour of using the other 'youtube' supported scheme.
+search_blacklist =
+    file
+    http
+    https
+    mms
+    rtmp
+    rtmps
+    rtsp
+    yt

--- a/mopidy_musicbox_webclient/static/index.html
+++ b/mopidy_musicbox_webclient/static/index.html
@@ -1,30 +1,14 @@
 <!DOCTYPE html>
 <html manifest="mb.appcache">
 <head>
-    <title>Musicbox</title>
+    <title>{{ title }}</title>
     <meta charset="utf-8">
-    <script type="text/javascript" src="vendors/jquery/jquery-1.12.0.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="vendors/jquery_mobile_flat_ui_theme/jquery.mobile.flatui.min.css"/>
-    <script>
-        //configuration
-        var isMusicBox = '{{musicbox}}' == 'True'; // Remove MusicBox only content (e.g. settings, system pages)
-        var websocketUrl = ('{{useWebsocketUrl}}' == 'True') ? '{{websocket_url}}' : ''
-        var hasAlarmClock = '{{alarmclock}}' == 'True'; // Add Alarm Clock icons
 
-        $(document).bind("mobileinit", function () {
-            $.extend($.mobile, {
-                ajaxEnabled: false,
-                hashListeningEnabled: false
-                //                    linkBindingEnabled: false
-                //                  buttonMarkup.hoverDelay: 100,
-                //                  buttonMarkup.corners: false
-            });
-        });
-/*        window.addEventListener('load', function () {
-            new FastClick(document.body);
-        }, false);
-*/
-    </script>
+    <script type="text/javascript" src="vendors/jquery/jquery-1.12.0.min.js"></script>
+    <script type="text/javascript" src="vendors/jquery_cookie/jquery.cookie.js"></script>
+    <script type="text/javascript" src="js/custom_scripting.js"></script>
+
+    <link rel="stylesheet" type="text/css" href="vendors/jquery_mobile_flat_ui_theme/jquery.mobile.flatui.min.css"/>
     <link rel="icon" type="image/gif" href="images/icons/musicbox32.gif" />
     <link rel="apple-touch-icon" href="images/icons/musicbox57.png" />
     <link rel="apple-touch-icon" sizes="72x72" href="images/icons/musicbox72.png" />
@@ -52,7 +36,7 @@
 
 </head>
 
-<body>
+<body data-web-socket-url="{{websocketUrl}}" data-is-musicbox="{{isMusicBox}}" data-has-alarmclock="{{hasAlarmClock}}">
 <div data-role="page" id="page" class="ui-responsive-panel" data-theme="c">
 <div data-role="panel" id="panel" data-position="left" data-theme="a" data-display="reveal" data-position-fixed="true">
 
@@ -501,7 +485,6 @@
 </div>
 <!-- /page one -->
 <script type="text/javascript" src="vendors/mopidy/mopidy.min.js"></script>
-<script type="text/javascript" src="vendors/jquery_cookie/jquery.cookie.js"></script>
 <script type="text/javascript" src="vendors/media_progress_timer/timer.js"></script>
 <script type="text/javascript" src="js/progress_timer.js"></script>
 <script type="text/javascript" src="js/controls.js"></script>

--- a/mopidy_musicbox_webclient/static/js/custom_scripting.js
+++ b/mopidy_musicbox_webclient/static/js/custom_scripting.js
@@ -1,0 +1,8 @@
+// jQuery Mobile configuration options
+// see: http://api.jquerymobile.com/1.3/global-config/
+$(document).bind('mobileinit', function () {
+    $.extend($.mobile, {
+        ajaxEnabled: false,
+        hashListeningEnabled: false
+    })
+})

--- a/mopidy_musicbox_webclient/static/js/functionsvars.js
+++ b/mopidy_musicbox_webclient/static/js/functionsvars.js
@@ -94,6 +94,7 @@ var uriClassList = [
 ]
 
 var uriHumanList = [
+    ['all', 'All services'],
     ['spotify', 'Spotify'],
     ['spotifytunigo', 'Spotify browse'],
     ['local', 'Local files'],

--- a/mopidy_musicbox_webclient/static/js/gui.js
+++ b/mopidy_musicbox_webclient/static/js/gui.js
@@ -475,6 +475,7 @@ $(document).ready(function (event) {
     $(window).hashchange()
 
     // Connect to server
+    var websocketUrl = $(document.body).data('web-socket-url')
     if (websocketUrl) {
         try {
             mopidy = new Mopidy({
@@ -539,16 +540,16 @@ $(document).ready(function (event) {
         }
     })
 
-    // remove buttons only for MusicBox
-    if (!isMusicBox) {
+    // Remove MusicBox only content (e.g. settings, system pages)
+    if (!$(document.body).data('is-musicbox')) {
         $('#navSettings').hide()
         $('#navshutdown').hide()
         $('#homesettings').hide()
         $('#homeshutdown').hide()
     }
 
-    // remove Alarm Clock if it is not present
-    if (!hasAlarmClock) {
+    // Remove Alarm Clock icons if it is not present
+    if (!$(document.body).data('has-alarmclock')) {
         $('#navAlarmClock').hide()
         $('#homeAlarmClock').hide()
         $('#homeAlarmClock').nextAll().find('.ui-block-a, .ui-block-b').toggleClass('ui-block-a').toggleClass('ui-block-b')

--- a/mopidy_musicbox_webclient/static/js/library.js
+++ b/mopidy_musicbox_webclient/static/js/library.js
@@ -1,3 +1,5 @@
+{% autoescape None %}
+
 var library = {
 
 /** *******************************
@@ -322,16 +324,14 @@ var library = {
             searchScheme = 'all'
         }
         $('#selectSearchService').empty()
-        $('#selectSearchService').append(new Option('All backends', 'all'))
-        mopidy.getUriSchemes().then(function (schemesArray) {
-            for (var i = 0; i < schemesArray.length; i++) {
-                backendName = getMediaHuman(schemesArray[i])
-                backendName = backendName.charAt(0).toUpperCase() + backendName.slice(1)
-                $('#selectSearchService').append(new Option(backendName, schemesArray[i]))
-            }
-            $('#selectSearchService').val(searchScheme)
-            $('#selectSearchService').selectmenu('refresh', true)
-        }, console.error)
+        var schemesArray = {{ searchSchemes }}
+        for (var i = 0; i < schemesArray.length; i++) {
+            backendName = getMediaHuman(schemesArray[i])
+            backendName = backendName.charAt(0).toUpperCase() + backendName.slice(1)
+            $('#selectSearchService').append(new Option(backendName, schemesArray[i]))
+        }
+        $('#selectSearchService').val(searchScheme)
+        $('#selectSearchService').selectmenu('refresh', true)
     }
 }
 

--- a/mopidy_musicbox_webclient/static/mb.appcache
+++ b/mopidy_musicbox_webclient/static/mb.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-# 2016-03-19:v1
+# 2016-03-21:v1
 
 NETWORK:
 *
@@ -19,12 +19,11 @@ images/icons/play_alt_12x12.png
 images/icons/play_alt_16x16.png
 images/loader.gif
 images/user_24x32.png
-index.html
 js/controls.js
+js/custom_scripting.js
 js/functionsvars.js
 js/gui.js
 js/images.js
-js/library.js
 js/process_ws.js
 js/progress_timer.js
 mb.appcache

--- a/mopidy_musicbox_webclient/web.py
+++ b/mopidy_musicbox_webclient/web.py
@@ -1,10 +1,13 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import json
 
 import logging
+import string
 
 import tornado.web
 
-from . import MusicBoxExtension
+import mopidy_musicbox_webclient.webclient as mmw
 
 logger = logging.getLogger(__name__)
 
@@ -21,40 +24,49 @@ class StaticHandler(tornado.web.StaticFileHandler):
 
     @classmethod
     def get_version(cls, settings, path):
-        return MusicBoxExtension.version
+        return mmw.Extension.version
 
 
 class IndexHandler(tornado.web.RequestHandler):
 
-    def initialize(self, config, path):
-        ext_config = config[MusicBoxExtension.ext_name]
-        host, port = ext_config['websocket_host'], ext_config['websocket_port']
-        ws_url = ''
-        if host or port:
-            if not host:
-                host = self.request.host.partition(':')[0]
-                logger.warning('Musicbox websocket_host not specified, '
-                               'using %s', host)
-            elif not port:
-                port = config['http']['port']
-                logger.warning('Musicbox websocket_port not specified, '
-                               'using %s', port)
-            protocol = 'ws'
-            if self.request.protocol == 'https':
-                protocol = 'wss'
-            ws_url = "%s://%s:%d/mopidy/ws" % (protocol, host, port)
+    def initialize(self, config, core, path):
+
+        webclient = mmw.Webclient(config, core)
 
         self.__dict = {
-            'version': MusicBoxExtension.version,
-            'musicbox': ext_config.get('musicbox', False),
-            'useWebsocketUrl': ws_url != '',
-            'websocket_url': ws_url,
-            'alarmclock': config.get('alarmclock', {}).get('enabled', False),
+            'isMusicBox': json.dumps(webclient.is_music_box()),
+            'websocketUrl': webclient.get_websocket_url(self.request),
+            'hasAlarmClock': json.dumps(webclient.has_alarm_clock()),
+        }
+        self.__path = path
+        self.__title = string.Template('MusicBox on $hostname')
+
+    def get(self, path):
+        return self.render(path, title=self.get_title(), **self.__dict)
+
+    def get_title(self):
+        hostname, sep, port = self.request.host.rpartition(':')
+        if not sep or not port.isdigit():
+            hostname, port = self.request.host, '80'
+        return self.__title.safe_substitute(hostname=hostname, port=port)
+
+    def get_template_path(self):
+        return self.__path
+
+
+class ScriptHandler(tornado.web.RequestHandler):
+
+    def initialize(self, config, core, path):
+
+        webclient = mmw.Webclient(config, core)
+
+        self.__dict = {
+            'searchSchemes': json.dumps(webclient.get_search_schemes())
         }
         self.__path = path
 
     def get(self, path):
-        return self.render('index.html', **self.__dict)
+        return self.render(path, **self.__dict)
 
     def get_template_path(self):
         return self.__path

--- a/mopidy_musicbox_webclient/webclient.py
+++ b/mopidy_musicbox_webclient/webclient.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+
+from mopidy_musicbox_webclient import Extension
+
+logger = logging.getLogger(__name__)
+
+
+class Webclient(object):
+
+    def __init__(self, config, core):
+        self.config = config
+        self.core = core
+
+    @property
+    def ext_config(self):
+        return self.config.get(Extension.ext_name, {})
+
+    def get_version(self):
+        return Extension.version
+
+    def get_search_schemes(self):
+        uri_schemes = self.core.get_uri_schemes()
+        search_blacklist = self.ext_config.get('search_blacklist', [])
+        search_schemes = sorted(list(set(uri_schemes.get()) - set(search_blacklist)))
+        search_schemes.insert(0, 'all')
+        return search_schemes
+
+    def get_websocket_url(self, request):
+        host, port = self.ext_config['websocket_host'], self.ext_config['websocket_port']
+        ws_url = ''
+        if host or port:
+            if not host:
+                host = request.host.partition(':')[0]
+                logger.warning('Musicbox websocket_host not specified, '
+                               'using %s', host)
+            elif not port:
+                port = self.config['http']['port']
+                logger.warning('Musicbox websocket_port not specified, '
+                               'using %s', port)
+            protocol = 'ws'
+            if request.protocol == 'https':
+                protocol = 'wss'
+            ws_url = "%s://%s:%d/mopidy/ws" % (protocol, host, port)
+
+        return ws_url
+
+    def has_alarm_clock(self):
+        return self.ext_config.get('alarmclock', {}).get('enabled', False)
+
+    def is_music_box(self):
+        return self.ext_config.get('musicbox', False)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     entry_points={
         'mopidy.ext': [
-            'musicbox_webclient = mopidy_musicbox_webclient:MusicBoxExtension',
+            'musicbox_webclient = mopidy_musicbox_webclient:Extension',
         ],
     },
     classifiers=[

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,22 +1,39 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-from mopidy_musicbox_webclient import MusicBoxExtension
+import unittest
 
+import mock
 
-def test_get_default_config():
-    ext = MusicBoxExtension()
-
-    config = ext.get_default_config()
-
-    assert '[musicbox_webclient]' in config
-    assert 'enabled = true' in config
+from mopidy_musicbox_webclient import Extension
 
 
-def test_get_config_schema():
-    ext = MusicBoxExtension()
+class ExtensionTests(unittest.TestCase):
 
-    schema = ext.get_config_schema()
-    assert 'musicbox' in schema
+    def test_get_default_config(self):
+        ext = Extension()
 
+        config = ext.get_default_config()
 
-# TODO Write more tests
+        assert '[musicbox_webclient]' in config
+        assert 'enabled = true' in config
+        assert 'websocket_host =' in config
+        assert 'websocket_port =' in config
+        assert 'search_blacklist =' in config
+
+    def test_get_config_schema(self):
+        ext = Extension()
+
+        schema = ext.get_config_schema()
+
+        assert 'musicbox' in schema
+        assert 'websocket_host' in schema
+        assert 'websocket_port' in schema
+        assert 'search_blacklist' in schema
+
+    def test_setup(self):
+        registry = mock.Mock()
+
+        ext = Extension()
+        ext.setup(registry)
+        calls = [mock.call('http:app', {'name': ext.ext_name, 'factory': ext.factory})]
+        registry.add.assert_has_calls(calls, any_order=True)

--- a/tests/test_library.js
+++ b/tests/test_library.js
@@ -7,7 +7,7 @@ chai.use(require('chai-jquery'))
 
 var sinon = require('sinon')
 
-var coverArt = require('../mopidy_musicbox_webclient/static/js/library.js')
+var library = require('../mopidy_musicbox_webclient/static/js/library.js')
 
 var selectID = '#selectSearchService'
 var schemesArray
@@ -19,7 +19,7 @@ before(function () {
 describe('Library', function () {
     describe('#getSearchSchemes()', function () {
         beforeEach(function () {
-            schemesArray = ['mockScheme1', 'mockScheme2', 'mockScheme3']
+            schemesArray = ['all', 'mockScheme1', 'mockScheme2', 'mockScheme3']
             mopidy = {
                 getUriSchemes: function () { return $.when(schemesArray) }
             }
@@ -30,7 +30,7 @@ describe('Library', function () {
             uriHumanList = [['mockScheme2', 'mockUriHuman2']]
 
             library.getSearchSchemes()
-            assert($(selectID).children().length === schemesArray.length + 1)
+            assert($(selectID).children().length === schemesArray.length)
             $(selectID).children(':eq(2)').should.have.text('MockUriHuman2')
         })
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import mock
+
+import mopidy.config as config
+
+import tornado.testing
+import tornado.web
+import tornado.websocket
+
+from mopidy_musicbox_webclient import Extension
+
+
+class BaseTest(tornado.testing.AsyncHTTPTestCase):
+
+    def get_app(self):
+        musicbox_webclient = Extension()
+        self.config = config.Proxy({'musicbox_webclient': {
+            'enabled': True,
+            'musicbox': True,
+            'websocket_host': '',
+            'websocket_port': '',
+            'search_blacklist': '',
+            }
+        })
+        return tornado.web.Application(musicbox_webclient.factory(self.config, mock.Mock()))
+
+
+class StaticFileHandlerTest(BaseTest):
+
+    def test_static_handler(self):
+        response = self.fetch('/vendors/mopidy/mopidy.js', method='GET')
+
+        self.assertEqual(200, response.code)
+
+
+class RedirectHandlerTest(BaseTest):
+
+    def test_redirect_handler(self):
+        response = self.fetch('/', method='GET', follow_redirects=False)
+
+        self.assertEqual(response.code, 301)
+        self.assertEqual(response.headers['Location'], 'index.html')
+
+
+class IndexHandlerTest(BaseTest):
+
+    def test_index_handler(self):
+        response = self.fetch('/index.html', method='GET')
+        self.assertEqual(200, response.code)
+
+    def test_get_title(self):
+        response = self.fetch('/index.html', method='GET')
+        body = tornado.escape.to_unicode(response.body)
+
+        self.assertIn('<title>MusicBox on localhost</title>', body)

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,18 @@
 envlist = py27, flake8, test, eslint, csslint, tidy
 
 [testenv]
+sitepackages = true
+whitelist_externals =
+    py.test
 deps =
     mock
     mopidy
     pytest
+    pytest-capturelog
     pytest-cov
     pytest-xdist
+    responses
+install_command = pip install --allow-unverified=mopidy --pre {opts} {packages}
 commands =
     py.test \
         --basetemp={envtmpdir} \
@@ -16,13 +22,17 @@ commands =
         {posargs:tests/}
 
 [testenv:flake8]
+sitepackages = false
 deps =
     flake8
     flake8-import-order
+    pep8-naming
 skip_install = true
-commands = flake8 {posargs:mopidy_musicbox_webclient tests}
+commands = flake8 --show-source --statistics --max-line-length 120 {posargs:mopidy_musicbox_webclient tests}
 
 [testenv:test]
+envdir = py27
+sitepackages = false
 whitelist_externals =
     /bin/bash
 deps =
@@ -33,6 +43,7 @@ commands =
     bash -c '. {toxworkdir}/node_env/bin/activate; npm install; npm test'
 
 [testenv:eslint]
+sitepackages = false
 whitelist_externals =
     /bin/bash
 deps =
@@ -43,6 +54,7 @@ commands =
     bash -c '. {toxworkdir}/node_env/bin/activate; npm install; npm run eslint'
 
 [testenv:csslint]
+sitepackages = false
 whitelist_externals =
     /bin/bash
 deps =
@@ -53,6 +65,7 @@ commands =
     bash -c '. {toxworkdir}/node_env/bin/activate; npm install; npm run csslint'
 
 [testenv:tidy]
+sitepackages = false
 whitelist_externals =
     /bin/bash
 deps =


### PR DESCRIPTION
So...this is the Tornado template-based alternative to https://github.com/pimusicbox/mopidy-musicbox-webclient/pull/186.

I'll readily admit that I have absolutely no experience using Tornado or templates, so please review the code to see if I am on the right track.

- At the moment we are using two different approaches for getting data from the model into the template: (a) storing them in ``<body data-xxx>`` tags and then retrieving with ``$(document.body).data('xxx')``, and (b) just injecting JSON strings directly into the JavaScript using Tornado's ``{{ xxx }}`` token format. I think (a) is neater but this will soon become impractical as we add more content, so we'll probably have to standardise on (b).
- I'm assuming that we'll need a different request handler for each JavaScript file so that we *just* make the Mopidy calls that are required to serve that script. Having a 1:1 mapping between Python models, request handlers, and JavaScript files seems crazy to me, so I am sure that I am doing this wrong - please advise? Worst case we end up having a different .js file for each method call?

Please ignore the test failures for now: due to the fact that we are injecting Tornado template tokens, parsing the raw JavaScript files causes eslint parsing errors (fun). I'll see if I can find a workaround for this in due course.

I still like the websocket-based approach better =)