### PR TITLE
Fix alarm clock detection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,7 @@ v2.4.0 (UNRELEASED)
 
 **Fixes**
 
+- Fixed `Alarm Clock <https://pypi.python.org/pypi/Mopidy-AlarmClock/>`_ detection.
 - Only show 'Show Album' or 'Show Artist' options in popup menus if URI's for those resources are available.
   (Fixes: `#213 <https://github.com/pimusicbox/mopidy-musicbox-webclient/issues/213>`_).
 - Now shows correct hostname information in loader popup. (Fixes: `#209 <https://github.com/pimusicbox/mopidy-musicbox-webclient/issues/209>`_).

--- a/mopidy_musicbox_webclient/webclient.py
+++ b/mopidy_musicbox_webclient/webclient.py
@@ -40,7 +40,7 @@ class Webclient(object):
         return ws_url
 
     def has_alarm_clock(self):
-        return self.ext_config.get('alarmclock', {}).get('enabled', False)
+        return self.config.get('alarmclock', {}).get('enabled', False)
 
     def is_music_box(self):
         return self.ext_config.get('musicbox', False)


### PR DESCRIPTION
Looks like AlarmClock detection has been broken during refactoring (in commit 411a3781fdab270984299e47f136abec8395ff57). 
This commit fixes alarm clock detection (and has been tested).