### PR TITLE
Recognize rtmp/-s and rtsp stream URIs as valid

### DIFF
--- a/mopidy_musicbox_webclient/static/js/functionsvars.js
+++ b/mopidy_musicbox_webclient/static/js/functionsvars.js
@@ -482,7 +482,7 @@ function showOffline (on) {
 
 // from http://dzone.com/snippets/validate-url-regexp
 function validUri (uri) {
-    var regexp = /^(mms|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/
+    var regexp = /^(http|https|mms|rtmp|rtmps|rtsp):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/
     return regexp.test(uri)
 }
 


### PR DESCRIPTION
Mopidy-Stream supports rtmp, rtmps and rtsp, too. There is no need to restrict the stream protocol support artificially to just http/-s and mms.