### PR TITLE
Scroll position is wrong when files have attributes

### DIFF
--- a/mopidy_musicbox_webclient/static/js/process_ws.js
+++ b/mopidy_musicbox_webclient/static/js/process_ws.js
@@ -113,9 +113,6 @@ function processBrowseDir (resultArr) {
     }
 
     $(BROWSE_TABLE).append(html)
-    if (browseStack.length > 0) {
-        window.scrollTo(0, browseStack[browseStack.length - 1].scrollPos || 0)  // Restore scroll position
-    }
 
     updatePlayIcons(songdata.track.uri, songdata.tlid, controls.getIconForAction())
 
@@ -139,6 +136,9 @@ function processBrowseDir (resultArr) {
                     }
                     renderSongLiDivider(previousTrack, track, nextTrack, BROWSE_TABLE)
                 }
+            }
+            if (browseStack.length > 0) {
+                window.scrollTo(0, browseStack[browseStack.length - 1].scrollPos || 0)  // Restore scroll position
             }
             showLoading(false)
         }, console.error)


### PR DESCRIPTION
Hi !

In the browser, when coming back from a directory, the scrolling of the previous directory is set before the file attributes (album name, etc...) are loaded, which results in a wrong scrolling if a lot of files have attributes because loading attributes changes the height of the scroll.

I simply moved the code that sets the scrolling after the code that loads file attributes.