### PR TITLE
support IPv6 address

### DIFF
--- a/mopidy_musicbox_webclient/web.py
+++ b/mopidy_musicbox_webclient/web.py
@@ -41,6 +41,10 @@ class IndexHandler(tornado.web.RequestHandler):
 
         url = urlparse.urlparse('%s://%s' % (self.request.protocol, self.request.host))
         port = url.port or 80
+        try:
+            ip = socket.getaddrinfo(url.hostname, port)[0][4][0]
+        except Exception:
+            ip = url.hostname
 
         self.__dict = {
             'isMusicBox': json.dumps(webclient.is_music_box()),
@@ -49,7 +53,7 @@ class IndexHandler(tornado.web.RequestHandler):
             'onTrackClick': webclient.get_default_click_action(),
             'programName': program_name,
             'hostname': url.hostname,
-            'serverIP': socket.gethostbyname(url.hostname),
+            'serverIP': ip,
             'serverPort': port
 
         }


### PR DESCRIPTION
As [`socket.gethostbyname()` only supports IPv4](https://docs.python.org/2/library/socket.html#socket.gethostbyname), use `socket.getaddrinfo()` instead to support IPv6 address.

Solve the issue #265